### PR TITLE
Fix memory leak in operator= overload

### DIFF
--- a/stringholder.cpp
+++ b/stringholder.cpp
@@ -43,6 +43,7 @@ StringHolder & StringHolder::operator=(const StringHolder &source) {
         delete string_;
         string_ = new std::string( *(source.string_));
     } else {
+        delete string_;
         string_ = nullptr;
     }
     return *this;

--- a/tests.cpp
+++ b/tests.cpp
@@ -9,3 +9,10 @@ TEST_CASE( "String Constructor", "[stringholder]" ) {
     
     REQUIRE( std::string(hello.c_str()) == "hello, world." );
 }
+
+TEST_CASE ( "Assignment operator works when assigned to null string", "[stringholder]" ) {
+    StringHolder hello("hello, world.");
+    StringHolder nullString;
+    hello = nullString;
+    REQUIRE( std::string(hello.c_str()) == "");
+}


### PR DESCRIPTION
I dont think I can test memory leaks with catch, but here's the error:  
Test case main.cpp which makes the code have a memory leak:
```
#include <iostream>

#include "stringholder.h"

int main() {
    StringHolder hello("hello, world.");
    StringHolder nullString;
    hello = nullString;
    return 0;
}
```

Output of `valgrind ./stringholder`:
```
==10655== Memcheck, a memory error detector
==10655== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==10655== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==10655== Command: ./stringholder
==10655== 
==10655== 
==10655== HEAP SUMMARY:
==10655==     in use at exit: 32 bytes in 1 blocks
==10655==   total heap usage: 2 allocs, 1 frees, 72,736 bytes allocated
==10655== 
==10655== LEAK SUMMARY:
==10655==    definitely lost: 32 bytes in 1 blocks
==10655==    indirectly lost: 0 bytes in 0 blocks
==10655==      possibly lost: 0 bytes in 0 blocks
==10655==    still reachable: 0 bytes in 0 blocks
==10655==         suppressed: 0 bytes in 0 blocks
==10655== Rerun with --leak-check=full to see details of leaked memory
==10655== 
==10655== For counts of detected and suppressed errors, rerun with: -v
==10655== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Valgrind output after fix:
```
==10909== Memcheck, a memory error detector
==10909== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==10909== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==10909== Command: ./stringholder
==10909== 
==10909== 
==10909== HEAP SUMMARY:
==10909==     in use at exit: 0 bytes in 0 blocks
==10909==   total heap usage: 2 allocs, 2 frees, 72,736 bytes allocated
==10909== 
==10909== All heap blocks were freed -- no leaks are possible
==10909== 
==10909== For counts of detected and suppressed errors, rerun with: -v
==10909== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```